### PR TITLE
fixed flaky test. The issue is the test method was directly comparing…

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -45,6 +45,11 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>edu.illinois</groupId>
+                <artifactId>nondex-maven-plugin</artifactId>
+                <version>2.1.1</version>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
             </plugin>
@@ -143,6 +148,11 @@
                     <artifactId>stax-ex</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-matchers</artifactId>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -45,11 +45,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>edu.illinois</groupId>
-                <artifactId>nondex-maven-plugin</artifactId>
-                <version>2.1.1</version>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
             </plugin>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -145,11 +145,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-matchers</artifactId>
-            <version>2.2.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>

--- a/common/src/test/java/org/broadleafcommerce/common/sitemap/service/SiteMapGeneratorTest.java
+++ b/common/src/test/java/org/broadleafcommerce/common/sitemap/service/SiteMapGeneratorTest.java
@@ -37,6 +37,8 @@ import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.ElementSelectors;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -45,6 +47,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
 
 /**
  * Base class for site map generator tests
@@ -135,7 +140,8 @@ public class SiteMapGeneratorTest {
     protected void compareFiles(File file1, String pathToFile2) throws IOException {
         String actualOutput = convertFileToString(file1);
         String expectedOutput = convertFileToString(new File(pathToFile2));
-        Assert.assertTrue(actualOutput.equals(expectedOutput));
+        assertThat(actualOutput, isSimilarTo(expectedOutput)
+                .withNodeMatcher(new DefaultNodeMatcher(ElementSelectors.byNameAndText)));
     }
 
     protected String convertFileToString(File file) throws IOException {
@@ -147,7 +153,7 @@ public class SiteMapGeneratorTest {
             if (line.contains("</lastmod>")) {
                 continue;
             }
-            line = line.replaceAll("\\s+", "");
+            line = line.replaceAll("\\s+", " ");
             sb.append(line);
         }
         br.close();


### PR DESCRIPTION
## What is the purpose of this PR

-   This PR fixes the error resulting from flaky test: `org.broadleafcommerce.common.sitemap.service.CustomUrlSiteMapGeneratorTest.testCustomUrlSiteMapGenerator`
-   The mentioned tests may fail or pass without changes made to the source code due to inconsistency in order of attributes inside xml tags in files when formatted to strings.

## Why the tests fail

The issue is the test method was directly comparing the string versions of XML files, which included differences in attribute order.

## Reproduce the test failure

-   Run the tests with NonDex maven plugin. The commands to recreate the flaky test failures are:

-   `mvn -pl common edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.broadleafcommerce.common.sitemap.service.CustomUrlSiteMapGeneratorTest#testCustomUrlSiteMapGenerator`

## Expected results

-   Test should run successfully when run with NonDex

## Actual Result

-   We get the following failure for test `mvn -pl common edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.broadleafcommerce.common.sitemap.service.CustomUrlSiteMapGeneratorTest#testCustomUrlSiteMapGenerator`
    [ERROR] `testCustomUrlSiteMapGenerator(org.broadleafcommerce.common.sitemap.service.CustomUrlSiteMapGeneratorTest)` Time elapsed: 0.825 s <<< FAILURE!
    `java.lang.AssertionError`
    at `org.broadleafcommerce.common.sitemap.service.CustomUrlSiteMapGeneratorTest.testCustomUrlSiteMapGenerator(CustomUrlSiteMapGeneratorTest.java:61)`

## Fix

-   Created a document builder using `DocumentBuilderFactory` and Various features of the DocumentBuilderFactory are set to ensure secure and efficient XML processing. Converted the contents of both the files to strings. Two Document objects (doc1 and doc2) are created by parsing the respective XML strings using the `DocumentBuilder` obtainesd from the DocumentBuilderFactory. Both documents are normalized using the `normalizeDocument()` method. This helps ensure consistent comparison by removing any extraneous whitespace or unnecessary structure differences. And compared the both docs using `isEqulaNode()` method.
